### PR TITLE
We want to actually inline the utility functions.

### DIFF
--- a/include/ada/mimesniff/parser.h
+++ b/include/ada/mimesniff/parser.h
@@ -1,5 +1,8 @@
-#include <string>
+#ifndef ADA_MIMESNIFF_PARSER_H
+#define ADA_MIMESNIFF_PARSER_H
+#include <string_view>
 
 namespace ada::mimesniff {
 void parse_mime_type(std::string_view input);
 }
+#endif

--- a/include/ada/mimesniff/util-inl.h
+++ b/include/ada/mimesniff/util-inl.h
@@ -1,0 +1,36 @@
+#ifndef ADA_MIMESNIFF_UTIL_INL_H
+#define ADA_MIMESNIFF_UTIL_INL_H
+#include <string_view>
+#include "ada/mimesniff/util.h"
+namespace ada::mimesniff {
+
+// https://fetch.spec.whatwg.org/#http-whitespace
+constexpr inline bool is_http_whitespace(const char c) {
+  return c == '\r' || c == '\n' || c == '\t' || c == ' ';
+}
+
+constexpr inline void trim_http_whitespace(std::string_view& input) {
+  while (!input.empty() && is_http_whitespace(input.front())) {
+    input.remove_prefix(1);
+  }
+  while (!input.empty() && is_http_whitespace(input.back())) {
+    input.remove_suffix(1);
+  }
+}
+
+constexpr static inline bool is_http_token(const char c) {
+  return isalnum(c) ||
+         (c == '!' || c == '#' || c == '$' || c == '%' || c == '&' ||
+          c == '\'' || c == '*' || c == '+' || c == '-' || c == '.' ||
+          c == '^' || c == '_' || c == '`' || c == '|' || c == '~');
+}
+
+constexpr inline bool contains_only_http_tokens(std::string_view view) {
+  // An HTTP token code point is U+0021 (!), U+0023 (#), U+0024 ($),
+  // U+0025 (%), U+0026 (&), U+0027 ('), U+002A (*), U+002B (+), U+002D (-),
+  // U+002E (.), U+005E (^), U+005F (_), U+0060 (`), U+007C (|), U+007E (~), or
+  // an ASCII alphanumeric.
+  return (std::all_of(view.begin(), view.end(), is_http_token));
+}
+}  // namespace ada::mimesniff
+#endif

--- a/include/ada/mimesniff/util.h
+++ b/include/ada/mimesniff/util.h
@@ -1,9 +1,11 @@
-#include <string>
-
+#ifndef ADA_MIMESNIFF_UTIL_H
+#define ADA_MIMESNIFF_UTIL_H
+#include <string_view>
 namespace ada::mimesniff {
-void trim_http_whitespace(std::string_view& input);
+constexpr inline void trim_http_whitespace(std::string_view& input);
 
-bool is_http_whitespace(const char c);
+constexpr inline bool is_http_whitespace(const char c);
 
-bool contains_only_http_tokens(std::string_view view);
+constexpr inline bool contains_only_http_tokens(std::string_view view);
 }  // namespace ada::mimesniff
+#endif

--- a/singleheader/amalgamate.py
+++ b/singleheader/amalgamate.py
@@ -103,9 +103,9 @@ except:
 print(f"timestamp is {timestamp}")
 
 os.makedirs(AMALGAMATE_OUTPUT_PATH, exist_ok=True)
-AMAL_H = os.path.join(AMALGAMATE_OUTPUT_PATH, "mimesniff.h")
-AMAL_C = os.path.join(AMALGAMATE_OUTPUT_PATH, "mimesniff.cpp")
-DEMOCPP = os.path.join(AMALGAMATE_OUTPUT_PATH, "cpp")
+AMAL_H = os.path.join(AMALGAMATE_OUTPUT_PATH, "ada_mimesniff.h")
+AMAL_C = os.path.join(AMALGAMATE_OUTPUT_PATH, "ada_mimesniff.cpp")
+DEMOCPP = os.path.join(AMALGAMATE_OUTPUT_PATH, "demo.cpp")
 README = os.path.join(AMALGAMATE_OUTPUT_PATH, "README.md")
 
 print(f"Creating {AMAL_H}")
@@ -128,12 +128,11 @@ amal_c.close()
 # copy the README and DEMOCPP
 if SCRIPTPATH != AMALGAMATE_OUTPUT_PATH:
   shutil.copy2(os.path.join(SCRIPTPATH,"demo.cpp"),AMALGAMATE_OUTPUT_PATH)
-  shutil.copy2(os.path.join(SCRIPTPATH,"demo.c"),AMALGAMATE_OUTPUT_PATH)
   shutil.copy2(os.path.join(SCRIPTPATH,"README.md"),AMALGAMATE_OUTPUT_PATH)
 
 zf = zipfile.ZipFile(os.path.join(AMALGAMATE_OUTPUT_PATH,'singleheader.zip'), 'w', zipfile.ZIP_DEFLATED)
-zf.write(os.path.join(AMALGAMATE_OUTPUT_PATH,"mimesniff.cpp"), "mimesniff.cpp")
-zf.write(os.path.join(AMALGAMATE_OUTPUT_PATH,"mimesniff.h"), "mimesniff.h")
+zf.write(os.path.join(AMALGAMATE_OUTPUT_PATH,"ada_mimesniff.cpp"), "ada_mimesniff.cpp")
+zf.write(os.path.join(AMALGAMATE_OUTPUT_PATH,"ada_mimesniff.h"), "ad_mimesniff.h")
 
 
 print("Done with all files generation.")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -3,7 +3,7 @@ target_include_directories(ada-mimesniff-include-source INTERFACE $<BUILD_INTERF
 add_library(ada-mimesniff-source INTERFACE)
 target_sources(ada-mimesniff-source INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>/mimesniff.cpp)
 target_link_libraries(ada-mimesniff-source INTERFACE ada-include-source)
-add_library(ada-mimesniff STATIC mimesniff.cpp util.cpp parser.cpp ../include/ada/mimesniff/parser.h)
+add_library(ada-mimesniff STATIC mimesniff.cpp util.cpp parser.cpp)
 target_include_directories(ada-mimesniff PRIVATE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}> )
 target_include_directories(ada-mimesniff PUBLIC "$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>")
 

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -1,6 +1,4 @@
-#include "util.cpp"
-
-#include <string>
+#include "ada/mimesniff/util-inl.h"
 
 namespace ada::mimesniff {
 void parse_mime_type(std::string_view input) {

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -1,37 +1,8 @@
 #include "ada/mimesniff/util.h"
 
 #include <algorithm>
-#include <string>
 
 namespace ada::mimesniff {
 
-// https://fetch.spec.whatwg.org/#http-whitespace
-bool is_http_whitespace(const char c) {
-  return c == '\r' || c == '\n' || c == '\t' || c == ' ';
-}
-
-void trim_http_whitespace(std::string_view& input) {
-  while (!input.empty() && is_http_whitespace(input.front())) {
-    input.remove_prefix(1);
-  }
-  while (!input.empty() && is_http_whitespace(input.back())) {
-    input.remove_suffix(1);
-  }
-}
-
-inline bool is_http_token(const char c) {
-  return isalnum(c) ||
-         (c == '!' || c == '#' || c == '$' || c == '%' || c == '&' ||
-          c == '\'' || c == '*' || c == '+' || c == '-' || c == '.' ||
-          c == '^' || c == '_' || c == '`' || c == '|' || c == '~');
-}
-
-bool contains_only_http_tokens(std::string_view view) {
-  // An HTTP token code point is U+0021 (!), U+0023 (#), U+0024 ($),
-  // U+0025 (%), U+0026 (&), U+0027 ('), U+002A (*), U+002B (+), U+002D (-),
-  // U+002E (.), U+005E (^), U+005F (_), U+0060 (`), U+007C (|), U+007E (~), or
-  // an ASCII alphanumeric.
-  return (std::all_of(view.begin(), view.end(), is_http_token));
-}
 
 }  // namespace ada::mimesniff


### PR DESCRIPTION
If you have small "utility" functions, you almost surely want the compiler to inline them which means that the definition *must* be available when compiling the function calling them. A standard way to do this, is to have '-inl.h' as well as '.h' files.

Note that not all header files need to go into include/ada/...

I have also fixed other small things.