### PR TITLE
subtype parsing

### DIFF
--- a/include/ada/mimesniff/util-inl.h
+++ b/include/ada/mimesniff/util-inl.h
@@ -19,6 +19,12 @@ constexpr inline void trim_http_whitespace(std::string_view& input) {
   }
 }
 
+constexpr inline void trim_trailing_http_whitespace(std::string_view& input) {
+  while (!input.empty() && is_http_whitespace(input.back())) {
+    input.remove_suffix(1);
+  }
+}
+
 // alphanum = 1, symbols = 2, other = 0
 constexpr static uint8_t http_tokens[256] = {
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,

--- a/include/ada/mimesniff/util.h
+++ b/include/ada/mimesniff/util.h
@@ -4,6 +4,8 @@
 namespace ada::mimesniff {
 constexpr inline void trim_http_whitespace(std::string_view& input);
 
+constexpr inline void trim_trailing_http_whitespace(std::string_view& input);
+
 constexpr inline bool is_http_whitespace(const char c);
 
 constexpr inline bool contains_only_http_tokens(std::string_view view);

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -1,27 +1,58 @@
 #include "ada/mimesniff/util-inl.h"
+#include <string>
 
 namespace ada::mimesniff {
 void parse_mime_type(std::string_view input) {
-  // step 1
+  // 1. Remove any leading and trailing HTTP whitespace from input.
   trim_http_whitespace(input);
 
-  // step 2
+  // 2. Let position be a position variable for input, initially
+  //    pointing at the start of input.
   size_t position = input.find_first_of('/');
 
-  // step 5
+  // 5. If position is past the end of input, then return failure.
+  // Also implements part of step 4.
   if (position == std::string_view::npos || position == 0) {
-    return;
+    return; // TODO: return failure
   }
 
-  // step 3
+  // 3. Let type be the result of collecting a sequence of code
+  //    points that are not U+002F (/) from input, given position.
   std::string_view type = input.substr(0, position);
 
-  // step 4
+  // 4. If type is the empty string or does not solely contain
+  //    HTTP token code points, then return failure.
   if (!contains_only_http_tokens(type)) {
-    return;
+    return; // TODO: return failure
   }
 
-  // step 6
+  // 6. Advance position by 1. (This skips past U+002F (/).)
   position++;
+
+  size_t subtype_end_position = input.find_first_of(';');
+
+  if (subtype_end_position == std::string_view::npos) {
+    // A mimetype may not have parameters. EG. "text/plain"
+    subtype_end_position = input.length();
+  } else if (subtype_end_position == 0) {
+    // If the string doesn't have a subtype, early return. This
+    // is part of step #9. EG. "text/"
+    return; // TODO: return failure
+  }
+
+  // 7. Let subtype be the result of collecting a sequence of code
+  //    points that are not U+003B (;) from input, given position.
+  std::string_view subtype = input.substr(
+      position, subtype_end_position);
+
+  // 8. Remove any trailing HTTP whitespace from subtype.
+  trim_trailing_http_whitespace(subtype);
+
+  // 9. If subtype is the empty string or does not solely contain
+  //    HTTP token code points, then return failure.
+  if (subtype.empty() ||
+      !contains_only_http_tokens(subtype)) {
+    return; // TODO: return failure
+  }
 }
 }  // namespace ada::mimesniff


### PR DESCRIPTION
```
  /**
   * text/html;charset=gbk    ;a=b
   *    |    |       |   |     | |
   *    |    |       |   |     | `------------------- parameter value
   *    |    |       |   |     `--------------------- parameter name
   *    |    |       |    `---------------------- parameter value end
   *    |    |       `--------------------------- parameter name end
   *    |    `----------------------------------- subtype end
   *    `---------------------------------------- type end
   */
```

So far we are parsing the `type` and, with this PR, the `subtype`. Couldn't test it out because of build failures but it should be good, I hope!