### PR TITLE
fix: append value if parameter has no closing quote

### DIFF
--- a/include/ada/mimesniff/util-inl.h
+++ b/include/ada/mimesniff/util-inl.h
@@ -101,6 +101,7 @@ inline std::string collect_http_quoted_string(std::string_view input,
     auto end_index = input.find_first_of("\"\\", position);
     // If position is past the end of input, then break.
     if (end_index == std::string_view::npos) {
+      value.append(input.substr(position));
       break;
     }
 


### PR DESCRIPTION
We weren't appending the value if there was no closing quote:
```
Append the result of collecting a sequence of code points that are not
U+0022 (") or U+005C (\) from input, given position, to value.
```