### PR TITLE
Some optimizations.

### DIFF
--- a/include/ada/mimesniff/util.h
+++ b/include/ada/mimesniff/util.h
@@ -12,8 +12,6 @@ constexpr inline void trim_trailing_http_whitespace(std::string_view& input);
 
 constexpr inline bool is_http_whitespace(char c);
 
-constexpr static inline bool is_http_token(char c);
-
 /**
  * Assuming that the view is UTF-8 encoded, we return true if its characters are
  * U+0009 TAB, a code point in the range U+0020 SPACE to U+007E (~) or in the
@@ -21,8 +19,16 @@ constexpr static inline bool is_http_token(char c);
  * @see https://mimesniff.spec.whatwg.org/#http-token-code-point
  */
 constexpr inline bool contains_only_http_tokens(std::string_view view);
+/**
+ * Assuming that the view is UTF-8 encoded, we return a byte value with the most
+ * significant bit set to 0 if its characters are
+ * U+0009 TAB, a code point in the range U+0020 SPACE to U+007E (~) or in the
+ * range U+0080 through U+00FF (ÿ), inclusive. The 3rd bit is set to 1 if an
+ * uppercase ASCII letter was found.
+ * @see https://mimesniff.spec.whatwg.org/#http-token-code-point
+ */
+constexpr inline uint8_t http_tokens_map(std::string_view view);
 
-constexpr static inline bool is_http_quoted_string_token(char c);
 
 /**
  * @see https://mimesniff.spec.whatwg.org/#http-quoted-string-token-code-point
@@ -39,5 +45,10 @@ inline std::string collect_http_quoted_string(std::string_view input,
  */
 constexpr bool to_lower_ascii(char* input, size_t length) noexcept;
 
+/**
+ * Lowers the ASCII letters in the string in-place. This function is optimized
+ * for short inputs (<= 8 characters).
+ */
+constexpr void to_lower_ascii_short(char* input, size_t length) noexcept;
 }  // namespace ada::mimesniff
 #endif


### PR DESCRIPTION
On our benchmarks, this PR improves our speed by about 10%. It is not much but the changes are tiny.



Intel Icelake, GCC 12...

Before ...

```
BasicBench_mean       155538 ns       155317 ns            3 GHz=3.19359 cycle/byte=49.6193 cycles/mime=559.33 instructions/byte=159.229 instructions/cycle=3.209 instructions/mime=1.79489k instructions/ns=10.2483 mime/s=5.67226M/s ns/mime=175.141 speed=63.9401M/s time/byte=15.6396ns time/mime=176.297ns
```

After this PR...

```
BasicBench_mean       138132 ns       137944 ns            3 GHz=3.19368 cycle/byte=44.3077 cycles/mime=499.455 instructions/byte=149.952 instructions/cycle=3.38434 instructions/mime=1.69033k instructions/ns=10.8085 mime/s=6.38667M/s ns/mime=156.389 speed=71.9932M/s time/byte=13.8902ns time/mime=156.576ns
```

For some context, the cost of parsing a mime is about 70% of the cost of parsing a URL. On a per byte basis, it takes 150 instructions per byte to parse a mime, and 25 instructions per byte to parse a URL.

The benchmarks are not directly comparable, but mime parsing is not cheap (yet).